### PR TITLE
Allows for alternate auth mode

### DIFF
--- a/src/MSGraph.php
+++ b/src/MSGraph.php
@@ -1,32 +1,37 @@
 <?php
+
 namespace ProcessMaker\Flysystem\Adapter;
 
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Stream;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\Config;
-use ProcessMaker\Flysystem\Adapter\MSGraph\AuthException;
-use ProcessMaker\Flysystem\Adapter\MSGraph\ModeException;
-use ProcessMaker\Flysystem\Adapter\MSGraph\SiteInvalidException;
-use League\OAuth2\Client\Provider\GenericProvider;
 use Microsoft\Graph\Graph;
 use Microsoft\Graph\Model;
+use ProcessMaker\Flysystem\Adapter\MSGraph\ModeException;
+use ProcessMaker\Flysystem\Adapter\MSGraph\SiteInvalidException;
 
 class MSGraph extends AbstractAdapter
 {
     const MODE_SHAREPOINT = 'sharepoint';
+
     const MODE_ONEDRIVE = 'onedrive';
 
     // Our mode, if sharepoint or onedrive
     private $mode;
+
     // Our Microsoft Graph Client
     private $graph;
+
     // Our Microsoft Graph Access Token
     private $token;
+
     // Our targetId, sharepoint site if sharepoint, drive id if onedrive
     private $targetId;
+
     // Our driveId, which if non empty points to a Drive
     private $driveId;
+
     // Our url prefix to be used for most file operations. This gets created in our constructor
     private $prefix;
 
@@ -43,98 +48,103 @@ class MSGraph extends AbstractAdapter
         $this->graph = $graph;
 
         // Check for existence
-        if($mode == self::MODE_SHAREPOINT) {
+        if ($mode == self::MODE_SHAREPOINT) {
             try {
-            $site = $this->graph->createRequest('GET', '/sites/' . $targetId)
-                ->setReturnType(Model\Site::class)
-                ->execute();
-            // Assign the site id triplet to our targetId
-            $this->targetId = $site->getId();
-            } catch(\Exception $e) {
-                if($e->getCode() == 400) {
+                $site = $this->graph->createRequest('GET', '/sites/' . $targetId)
+                    ->setReturnType(Model\Site::class)
+                    ->execute();
+                // Assign the site id triplet to our targetId
+                $this->targetId = $site->getId();
+            } catch (\Exception $e) {
+                if ($e->getCode() == 400) {
                     throw new SiteInvalidException("The sharepoint site " . $targetId . " is invalid.");
                 }
+
                 throw $e;
             }
             $this->prefix = "/sites/" . $this->targetId . '/drive/items/';
-            if($driveName != '') {
+            if ($driveName != '') {
                 // Then we specified a drive name, so let's enumerate the drives and find it
                 $drives = $this->graph->createRequest('GET', '/sites/' . $this->targetId . '/drives')
                     ->execute();
                 $drives = $drives->getBody()['value'];
-                foreach($drives as $drive) {
-                    if($drive['name'] == $driveName) {
+                foreach ($drives as $drive) {
+                    if ($drive['name'] == $driveName) {
                         $this->driveId = $drive['id'];
                         $this->prefix = "/drives/" . $this->driveId . "/items/";
+
                         break;
                     }
                 }
-                if(!$this->driveId) {
-                    throw new SiteInvalidException("The sharepoint drive with name " . $driveName  . " could not be found.");
+                if (! $this->driveId) {
+                    throw new SiteInvalidException("The sharepoint drive with name " . $driveName . " could not be found.");
                 }
-
             }
         }
-
     }
 
     public function has($path)
     {
-        if($this->mode == self::MODE_SHAREPOINT) {
+        if ($this->mode == self::MODE_SHAREPOINT) {
             try {
                 $driveItem = $this->graph->createRequest('GET', $this->prefix . 'root:/' . $path)
                     ->setReturnType(Model\DriveItem::class)
                     ->execute();
                 // Successfully retrieved meta data.
                 return true;
-            } catch(ClientException $e) {
-                if($e->getCode() == 404) {
+            } catch (ClientException $e) {
+                if ($e->getCode() == 404) {
                     // Not found, let's return false;
                     return false;
                 }
+
                 throw $e;
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 throw $e;
             }
         }
+
         return false;
     }
 
     public function read($path)
     {
-        if($this->mode == self::MODE_SHAREPOINT) {
+        if ($this->mode == self::MODE_SHAREPOINT) {
             try {
                 $driveItem = $this->graph->createRequest('GET', $this->prefix . 'root:/' . $path)
                     ->setReturnType(Model\DriveItem::class)
                     ->execute();
                 // Successfully retrieved meta data.
                 // Now get content
-                $contentStream = $this->graph->createRequest('GET', $this->prefix . $driveItem->getId() .'/content')
+                $contentStream = $this->graph->createRequest('GET', $this->prefix . $driveItem->getId() . '/content')
                     ->setReturnType(Stream::class)
                     ->execute();
                 $contents = '';
                 $bufferSize = 8012;
                 // Copy over the data into a string
-                while (!$contentStream->eof()) {
+                while (! $contentStream->eof()) {
                     $contents .= $contentStream->read($bufferSize);
                 }
+
                 return ['contents' => $contents];
-            } catch(ClientException $e) {
-                if($e->getCode() == 404) {
+            } catch (ClientException $e) {
+                if ($e->getCode() == 404) {
                     // Not found, let's return false;
                     return false;
                 }
+
                 throw $e;
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 throw $e;
             }
         }
+
         return false;
     }
 
     public function getUrl($path)
     {
-        if($this->mode == self::MODE_SHAREPOINT) {
+        if ($this->mode == self::MODE_SHAREPOINT) {
             try {
                 $driveItem = $this->graph->createRequest('GET', $this->prefix . 'root:/' . $path)
                     ->setReturnType(Model\DriveItem::class)
@@ -142,22 +152,23 @@ class MSGraph extends AbstractAdapter
                 // Successfully retrieved meta data.
                 // Return url property
                 return $driveItem->getWebUrl();
-            } catch(ClientException $e) {
-                if($e->getCode() == 404) {
+            } catch (ClientException $e) {
+                if ($e->getCode() == 404) {
                     // Not found, let's return false;
                     return false;
                 }
+
                 throw $e;
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 throw $e;
             }
         }
+
         return false;
     }
 
     public function readStream($path)
     {
-
     }
 
     public function listContents($directory = '', $recursive = false)
@@ -169,7 +180,7 @@ class MSGraph extends AbstractAdapter
                     ->execute();
                 // Successfully retrieved meta data.
                 // Now get content
-                $driveItems = $this->graph->createRequest('GET', $this->prefix . $drive->getId() .'/children')
+                $driveItems = $this->graph->createRequest('GET', $this->prefix . $drive->getId() . '/children')
                     ->setReturnType(Model\DriveItem::class)
                     ->execute();
 
@@ -179,6 +190,7 @@ class MSGraph extends AbstractAdapter
                     $item['path'] = $directory . '/' . $driveItem->getName();
                     $children[] = $item;
                 }
+
                 return $children;
             } catch (ClientException $e) {
                 throw $e;
@@ -186,77 +198,71 @@ class MSGraph extends AbstractAdapter
                 throw $e;
             }
         }
+
         return [];
     }
 
     public function getMetadata($path)
     {
-
     }
 
     public function getSize($path)
     {
-
     }
 
     public function getMimetype($path)
     {
-
     }
 
     public function getTimestamp($path)
     {
-
     }
 
     public function getVisibility($path)
     {
-
     }
 
     // Write methods
     public function write($path, $contents, Config $config)
     {
-        if($this->mode == self::MODE_SHAREPOINT) {
+        if ($this->mode == self::MODE_SHAREPOINT) {
             // Attempt to write to sharepoint
             $driveItem = $this->graph->createRequest('PUT', $this->prefix . 'root:/' . $path . ':/content')
-                                     ->attachBody($contents)
-                                     ->setReturnType(Model\DriveItem::class)
-                                     ->execute();
+                ->attachBody($contents)
+                ->setReturnType(Model\DriveItem::class)
+                ->execute();
 
             // Successfully created
             return true;
         }
+
+        return false;
     }
 
     public function writeStream($path, $resource, Config $config)
     {
-
     }
 
     public function update($path, $contents, Config $config)
     {
-
+        return $this->write($path, $contents, $config);
     }
 
     public function updateStream($path, $resource, Config $config)
     {
-
     }
 
     public function rename($path, $newpath)
     {
-
     }
 
     public function copy($path, $newpath)
     {
-
     }
 
     public function delete($path)
     {
-        if($this->mode == self::MODE_SHAREPOINT) {
+        if ($this->mode == self::MODE_SHAREPOINT) {
             try {
                 $driveItem = $this->graph->createRequest('GET', $this->prefix . 'root:/' . $path)
                     ->setReturnType(Model\DriveItem::class)
@@ -265,34 +271,32 @@ class MSGraph extends AbstractAdapter
                 // Now delete the file
                 $this->graph->createRequest('DELETE', $this->prefix . $driveItem->getId())
                     ->execute();
+
                 return true;
-            } catch(ClientException $e) {
-                if($e->getCode() == 404) {
+            } catch (ClientException $e) {
+                if ($e->getCode() == 404) {
                     // Not found, let's return false;
                     return false;
                 }
+
                 throw $e;
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 throw $e;
             }
         }
-        return false;
 
+        return false;
     }
 
     public function deleteDir($dirname)
     {
-
     }
 
     public function createDir($dirname, Config $config)
     {
-
     }
 
     public  function setVisibility($path, $visibility)
     {
-
     }
-
 }

--- a/src/MSGraph.php
+++ b/src/MSGraph.php
@@ -30,8 +30,16 @@ class MSGraph extends AbstractAdapter
     // Our url prefix to be used for most file operations. This gets created in our constructor
     private $prefix;
 
+    public function __construct($mode)
+    {
+        if ($mode != self::MODE_ONEDRIVE && $mode != self::MODE_SHAREPOINT) {
+            throw new ModeException("Unknown mode specified: " . $mode);
+        }
+    }
+
     public function initialize($graph, $mode = self::MODE_ONEDRIVE, $targetId, $driveName)
     {
+        $this->mode = $mode;
         $this->graph = $graph;
 
         // Check for existence
@@ -211,16 +219,13 @@ class MSGraph extends AbstractAdapter
     {
         if($this->mode == self::MODE_SHAREPOINT) {
             // Attempt to write to sharepoint
-            try {
-                $driveItem = $this->graph->createRequest('PUT', $this->prefix . 'root:/' . $path . ':/content')
-                    ->attachBody($contents)
-                    ->setReturnType(Model\DriveItem::class)
-                    ->execute();
-                // Successfully created
-                return true;
-            } catch(Exception $e) {
-                throw $e;
-            }
+            $driveItem = $this->graph->createRequest('PUT', $this->prefix . 'root:/' . $path . ':/content')
+                                     ->attachBody($contents)
+                                     ->setReturnType(Model\DriveItem::class)
+                                     ->execute();
+
+            // Successfully created
+            return true;
         }
     }
 

--- a/src/MSGraph.php
+++ b/src/MSGraph.php
@@ -61,13 +61,15 @@ class MSGraph extends AbstractAdapter
             } catch(IdentityProviderException $e) {
                 throw new AuthException($e->getMessage());
             }
+
+            $this->token = $this->token->getToken();
         } else if ($tokenMode === self::OAUTH_MODE_APP) {
             $this->token = $appModeToken;
         }
 
         // Assign graph instance
         $this->graph = new Graph();
-        $this->graph->setAccessToken($this->token->getToken());
+        $this->graph->setAccessToken($this->token);
 
         // Check for existence
         if($mode == self::MODE_SHAREPOINT) {

--- a/src/MSGraph.php
+++ b/src/MSGraph.php
@@ -9,7 +9,6 @@ use ProcessMaker\Flysystem\Adapter\MSGraph\AuthException;
 use ProcessMaker\Flysystem\Adapter\MSGraph\ModeException;
 use ProcessMaker\Flysystem\Adapter\MSGraph\SiteInvalidException;
 use League\OAuth2\Client\Provider\GenericProvider;
-use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Microsoft\Graph\Graph;
 use Microsoft\Graph\Model;
 

--- a/src/MSGraph.php
+++ b/src/MSGraph.php
@@ -18,9 +18,6 @@ class MSGraph extends AbstractAdapter
     const MODE_SHAREPOINT = 'sharepoint';
     const MODE_ONEDRIVE = 'onedrive';
 
-    const OAUTH_MODE_APP = 'oauth_app';
-    const OAUTH_MODE_USER = 'oauth_user';
-
     // Our mode, if sharepoint or onedrive
     private $mode;
     // Our Microsoft Graph Client
@@ -34,42 +31,9 @@ class MSGraph extends AbstractAdapter
     // Our url prefix to be used for most file operations. This gets created in our constructor
     private $prefix;
 
-    public function __construct($appId, $appPassword, $tokenMode, $mode = self::MODE_ONEDRIVE, $targetId, $driveName = null, $appModeToken = null)
+    public function initialize($graph, $mode = self::MODE_ONEDRIVE, $targetId, $driveName)
     {
-        if($mode != self::MODE_ONEDRIVE && $mode != self::MODE_SHAREPOINT) {
-            throw new ModeException("Unknown mode specified: " . $mode);
-        }
-        if($tokenMode != self::OAUTH_MODE_USER && $tokenMode != self::OAUTH_MODE_APP) {
-            throw new ModeException("Unknown token mode specified: " . $tokenMode);
-        }
-        $this->mode = $mode;
-
-        if ($tokenMode === self::OAUTH_MODE_USER) {
-            // Initialize the OAuth client
-            $oauthClient = new \League\OAuth2\Client\Provider\GenericProvider([
-                'clientId' => $appId,
-                'clientSecret' => $appPassword,
-                'urlAuthorize' => '',
-                'urlResourceOwnerDetails' => '',
-                'urlAccessToken' => $tokenEndpoint,
-            ]);
-
-            try {
-                $this->token = $oauthClient->getAccessToken('client_credentials', [
-                    'scope' => 'https://graph.microsoft.com/.default'
-                ]);
-            } catch(IdentityProviderException $e) {
-                throw new AuthException($e->getMessage());
-            }
-
-            $this->token = $this->token->getToken();
-        } else if ($tokenMode === self::OAUTH_MODE_APP) {
-            $this->token = $appModeToken;
-        }
-
-        // Assign graph instance
-        $this->graph = new Graph();
-        $this->graph->setAccessToken($this->token);
+        $this->graph = $graph;
 
         // Check for existence
         if($mode == self::MODE_SHAREPOINT) {

--- a/src/MSGraphApp.php
+++ b/src/MSGraphApp.php
@@ -8,9 +8,7 @@ class MSGraphApp extends MSGraph
 {
     public function __construct($mode = self::MODE_ONEDRIVE, $targetId, $driveName = null, $appModeToken = null)
     {
-        if($mode != self::MODE_ONEDRIVE && $mode != self::MODE_SHAREPOINT) {
-            throw new ModeException("Unknown mode specified: " . $mode);
-        }
+        parent::__construct($mode);
 
         // Assign graph instance
         $graph = new Graph();

--- a/src/MSGraphApp.php
+++ b/src/MSGraphApp.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ProcessMaker\Flysystem\Adapter;
+
+class MSGraphApp extends MSGraph
+{
+    public function __construct($mode = self::MODE_ONEDRIVE, $targetId, $driveName = null, $appModeToken = null)
+    {
+        if($mode != self::MODE_ONEDRIVE && $mode != self::MODE_SHAREPOINT) {
+            throw new ModeException("Unknown mode specified: " . $mode);
+        }
+
+        // Assign graph instance
+        $graph = new Graph();
+        $graph->setAccessToken($appModeToken);
+
+        $this->initialize($graph, $mode, $targetId, $driveName);
+    }
+}

--- a/src/MSGraphApp.php
+++ b/src/MSGraphApp.php
@@ -2,6 +2,8 @@
 
 namespace ProcessMaker\Flysystem\Adapter;
 
+use Microsoft\Graph\Graph;
+
 class MSGraphApp extends MSGraph
 {
     public function __construct($mode = self::MODE_ONEDRIVE, $targetId, $driveName = null, $appModeToken = null)

--- a/src/MSGraphUser.php
+++ b/src/MSGraphUser.php
@@ -2,6 +2,9 @@
 
 namespace ProcessMaker\Flysystem\Adapter;
 
+use Microsoft\Graph\Graph;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+
 class MSGraphUser extends MSGraph
 {
 

--- a/src/MSGraphUser.php
+++ b/src/MSGraphUser.php
@@ -10,9 +10,7 @@ class MSGraphUser extends MSGraph
 
     public function __construct($appId, $appPassword, $tokenEndpoint, $mode = self::MODE_ONEDRIVE, $targetId, $driveName = null)
     {
-        if($mode != self::MODE_ONEDRIVE && $mode != self::MODE_SHAREPOINT) {
-            throw new ModeException("Unknown mode specified: " . $mode);
-        }
+        parent::__construct($mode);
 
         // Initialize the OAuth client
         $oauthClient = new \League\OAuth2\Client\Provider\GenericProvider([

--- a/src/MSGraphUser.php
+++ b/src/MSGraphUser.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ProcessMaker\Flysystem\Adapter;
+
+class MSGraphUser extends MSGraph
+{
+
+    public function __construct($appId, $appPassword, $tokenEndpoint, $mode = self::MODE_ONEDRIVE, $targetId, $driveName = null)
+    {
+        if($mode != self::MODE_ONEDRIVE && $mode != self::MODE_SHAREPOINT) {
+            throw new ModeException("Unknown mode specified: " . $mode);
+        }
+
+        // Initialize the OAuth client
+        $oauthClient = new \League\OAuth2\Client\Provider\GenericProvider([
+            'clientId' => $appId,
+            'clientSecret' => $appPassword,
+            'urlAuthorize' => '',
+            'urlResourceOwnerDetails' => '',
+            'urlAccessToken' => $tokenEndpoint,
+        ]);
+
+        try {
+            $this->token = $oauthClient->getAccessToken('client_credentials', [
+                'scope' => 'https://graph.microsoft.com/.default'
+            ]);
+        } catch(IdentityProviderException $e) {
+            throw new AuthException($e->getMessage());
+        }
+
+        // Assign graph instance
+        $graph = new Graph();
+        $graph->setAccessToken($this->token->getToken());
+
+        $this->initialize($graph, $mode, $targetId, $driveName);
+    }
+}


### PR DESCRIPTION
We're using a generated token from the Azure system instead of Oauth via a user. Minor difference is that now you 

```
use ProcessMaker\Flysystem\Adapter\MSGraphApp as SharepointAdapter;

new SharepointAdapter(SharepointAdapter::MODE_SHAREPOINT, $sharepoint_site_id, $document_library, $access_token)
```

or 

```
use ProcessMaker\Flysystem\Adapter\MSGraphUser as SharepointAdapter;

new SharepointAdapter($appId, $appPassword, $tokenEndpoint, SharepointAdapter::MODE_SHAREPOINT, $sharepoint_site_id, $document_library)
```

Feedback welcome.